### PR TITLE
Updated text and method naming

### DIFF
--- a/Chapter01/2.First_transaction.ipynb
+++ b/Chapter01/2.First_transaction.ipynb
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "id": "8a69fedd",
    "metadata": {},
    "outputs": [],
@@ -27,7 +27,8 @@
    "source": [
     "## Ganache blockchain connection\n",
     "\n",
-    "The code below will connect to the local network using the Web3 library. It will create a connection to the localhost on port 8545 and store it in the variable `web3`. It will then use the `web3.isConnected()` method to check if the connection was successful and print the result."
+    "The code below will connect to the local network using the Web3 library. It will create a connection to the localhost on port 8545 and store it in the variable `web3`. It will then use the `web3.is_connected()` method to check if the connection was successful and print the result. \n",
+    "NOTE: Your RPC Server address will differ from the one in the screenshot below."
    ]
   },
   {
@@ -45,7 +46,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "e50ae836",
    "metadata": {},
    "outputs": [
@@ -60,7 +61,7 @@
    "source": [
     "ganache_url= \"http://127.0.0.1:8545\"\n",
     "web3= Web3(Web3.HTTPProvider(ganache_url))\n",
-    "print (\"Are we connected to the blockchain?:\", web3.isConnected())"
+    "print (\"Are we connected to the blockchain?:\", web3.is_connected())"
    ]
   },
   {
@@ -69,12 +70,12 @@
    "metadata": {},
    "source": [
     "## Checking the Current Block\n",
-    "Use the `web3.eth.blockNumber` method to check the current block number on our local network and print the result."
+    "Use the `web3.eth.block_number` method to check the current block number on our local network and print the result."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "1efd983c",
    "metadata": {},
    "outputs": [
@@ -82,12 +83,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "What is the current block? Current block is: 0\n"
+      "What is the current block? Current block is: 1\n"
      ]
     }
    ],
    "source": [
-    "print(\"What is the current block? Current block is:\", web3.eth.blockNumber)"
+    "print(\"What is the current block? Current block is:\", web3.eth.block_number)"
    ]
   },
   {
@@ -117,12 +118,12 @@
    "metadata": {},
    "source": [
     "#### Checking Account Balances\n",
-    "Use the `web3.eth.getBalance` method to check the balance of two accounts on the local network and print the results. The `from_account` and `to_account` variables are set to two Ethereum addresses that exist in the local netwok. The `web3.eth.getBalance` method is used to get the balance of each account in wei, and the `web3.fromWei` method is used to convert the balance from wei to ether. The results are then printed to the notebook."
+    "Use the `web3.eth.get_balance` method to check the balance of two accounts on the local network and print the results. The `from_account` and `to_account` variables are set to two Ethereum addresses that exist in the local netwok. The `web3.eth.get_balance` method is used to get the balance of each account in wei, and the `web3.from_wei` method is used to convert the balance from wei to ether. The results are then printed to the notebook."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 7,
    "id": "ebc78b8c",
    "metadata": {},
    "outputs": [
@@ -138,8 +139,8 @@
    "source": [
     "from_account=\"0xd5eAc5e5f45ddFCC698b0aD27C52Ba55b98F5653\"\n",
     "to_account= \"0xFfd597CE52103B287Efa55a6e6e0933dff314C63\"\n",
-    "print (\"How much money is in the sender's account? The balance is: \", web3.fromWei(web3.eth.getBalance(from_account),'ether'))\n",
-    "print (\"How much money is in the receiver's account? The balance is: \", web3.fromWei (web3.eth.getBalance(to_account), 'ether'))"
+    "print (\"How much money is in the sender's account? The balance is: \", web3.from_wei(web3.eth.get_balance(from_account),'ether'))\n",
+    "print (\"How much money is in the receiver's account? The balance is: \", web3.from_wei (web3.eth.get_balance(to_account), 'ether'))"
    ]
   },
   {
@@ -149,12 +150,12 @@
    "source": [
     "#### Sending Money\n",
     "\n",
-    "This code will use the `web3.eth.send_transaction` method to send 30 ether from the `from_account` to the `to_account`. The `transaction` variable is set to the result of the `web3.eth.send_transaction` method, which takes an object as an argument. The object contains the `to` and `from` addresses, as well as the `value` of the transaction in wei, which is converted from ether using the `web3.toWei` method."
+    "This code will use the `web3.eth.send_transaction` method to send 30 ether from the `from_account` to the `to_account`. The `transaction` variable is set to the result of the `web3.eth.send_transaction` method, which takes an object as an argument. The object contains the `to` and `from` addresses, as well as the `value` of the transaction in wei, which is converted from ether using the `web3.to_wei` method."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 9,
    "id": "d7cec78e",
    "metadata": {},
    "outputs": [],
@@ -162,7 +163,7 @@
     "transaction= web3.eth.send_transaction({\n",
     "  'to': to_account,\n",
     "  'from': from_account,\n",
-    "  'value': web3.toWei(30, \"ether\") \n",
+    "  'value': web3.to_wei(30, \"ether\") \n",
     "})"
    ]
   },
@@ -177,7 +178,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 10,
    "id": "1a662f2a",
    "metadata": {},
    "outputs": [
@@ -185,14 +186,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "How much money is in the sender's account? The balance is:  69.99958\n",
+      "How much money is in the sender's account? The balance is:  69.99997963295974\n",
       "How much money is in the receiver's account? The balance is:  130\n"
      ]
     }
    ],
    "source": [
-    "print (\"How much money is in the sender's account? The balance is: \", web3.fromWei(web3.eth.getBalance(from_account),'ether'))\n",
-    "print (\"How much money is in the receiver's account? The balance is: \", web3.fromWei (web3.eth.getBalance(to_account), 'ether'))"
+    "print (\"How much money is in the sender's account? The balance is: \", web3.from_wei(web3.eth.get_balance(from_account),'ether'))\n",
+    "print (\"How much money is in the receiver's account? The balance is: \", web3.from_wei (web3.eth.get_balance(to_account), 'ether'))"
    ]
   },
   {
@@ -220,7 +221,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 11,
    "id": "637a450f",
    "metadata": {},
    "outputs": [
@@ -228,12 +229,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "What is the current block? Current block is: 1\n"
+      "What is the current block? Current block is: 2\n"
      ]
     }
    ],
    "source": [
-    "print(\"What is the current block? Current block is:\", web3.eth.blockNumber)"
+    "print(\"What is the current block? Current block is:\", web3.eth.block_number)"
    ]
   },
   {
@@ -247,30 +248,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 12,
    "id": "e1e68601",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "AttributeDict({'hash': HexBytes('0x50d01c103ff4c421b8125afc1b97e8dab2cfee0c7e150b410231c896f163636b'),\n",
+       "AttributeDict({'type': 2,\n",
+       " 'hash': HexBytes('0xa52f0e623452cf54b1bd68cf63a7cf11b5a4602b00f854b030a6ae9d3f2773b1'),\n",
+       " 'chainId': 1337,\n",
        " 'nonce': 0,\n",
-       " 'blockHash': HexBytes('0x36fb6214283bc9ed5a203877f4a68e41c2a2742b3c9161fc25eda53081dc2b12'),\n",
-       " 'blockNumber': 1,\n",
+       " 'blockHash': HexBytes('0x5f34fb68c78e5c0e63cd5bc8b6e0a7cf22ead20d9164ed351e18f5fc97c8ad9e'),\n",
+       " 'blockNumber': 2,\n",
        " 'transactionIndex': 0,\n",
-       " 'from': '0xd5eAc5e5f45ddFCC698b0aD27C52Ba55b98F5653',\n",
-       " 'to': '0xFfd597CE52103B287Efa55a6e6e0933dff314C63',\n",
+       " 'from': '0x607Dc90851f8de32C76780E27145ca5d434d6d4C',\n",
+       " 'to': '0x6135D8602D0736b8F87361d4Ce7b50D0Fa7b90f1',\n",
        " 'value': 30000000000000000000,\n",
+       " 'maxPriorityFeePerGas': 1000000000,\n",
+       " 'maxFeePerGas': 969859060,\n",
+       " 'gasPrice': 969859060,\n",
        " 'gas': 121000,\n",
-       " 'gasPrice': 20000000000,\n",
-       " 'input': '0x',\n",
-       " 'v': 37,\n",
-       " 'r': HexBytes('0xdbd216095b185a8813767da571c9cbaa0812d61266c9e63fc579f12bebdbef3d'),\n",
-       " 's': HexBytes('0x081c6712849e0fb875aab6977928b71d77312e40dd683845cdbd0f349735559d')})"
+       " 'input': HexBytes('0x'),\n",
+       " 'accessList': [],\n",
+       " 'v': 1,\n",
+       " 'r': HexBytes('0x7a7ed0f7d06878a8b5a48262bac4a3aa594246b901425c940eca0cdd8c7f9239'),\n",
+       " 's': HexBytes('0x28879c7473ab605d9ccf258a50b511694ac807eda6d3e81274c581d205c79fc4')})"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -296,7 +302,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.11.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Recently bought the book and was enjoying browsing through it.
I noticed several methods used from the web3 package were deprecated or has been renamed in recent updates.
As such I want to assist in updating these going forward and the change to this one file was merely a test.

examples:
Methods such as "fromWei" have been updated to fit current notation as "from_wei"
Method "web3.isConnected()" changed to ned notation "web3.is_connected()"
Added additional note explaining the user/learner needs to get their own RPC server address from Ganache.